### PR TITLE
Added color parameter to LaserBeam constructor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ var laserBeam	= new THREEx.LaserBeam()
 scene.add(laserBeam)
 ```
 
+The constructor takes an optional argument, "color", which can be used to specify the beam color:
+
+```javascript
+var laserBeam	= new THREEx.LaserBeam({r: 255, g: 0, b: 0})
+scene.add(laserBeam)
+```
+
 ## threex.lasercooked.js
 It is a laser beam with dynamic collision. 
 On impacts, to increase realism, there is sprite and point light.

--- a/examples/demo.html
+++ b/examples/demo.html
@@ -43,7 +43,7 @@
 	var nLasers	= 14
 	for(var i = 0; i < nLasers; i++){
 		(function(){
-			var laserBeam	= new THREEx.LaserBeam()
+			var laserBeam	= new THREEx.LaserBeam({r: Math.random()*255, g: Math.random()*255, b: Math.random()*255})
 			scene.add(laserBeam.object3d)
 			var laserCooked	= new THREEx.LaserCooked(laserBeam)
 			onRenderFcts.push(function(delta, now){

--- a/threex.laserbeam.js
+++ b/threex.laserbeam.js
@@ -1,10 +1,20 @@
 var THREEx = THREEx || {}
 
-THREEx.LaserBeam	= function(){
+THREEx.LaserBeam	= function(color){
+	if (color === undefined) {
+		color = {
+			r: 255,
+			g: 255,
+			b: 255
+		};
+	}
+	color.r = Math.floor(color.r);
+	color.g = Math.floor(color.g);
+	color.b = Math.floor(color.b);
 	var object3d	= new THREE.Object3D()
 	this.object3d	= object3d
 	// generate the texture
-	var canvas	= generateLaserBodyCanvas()
+	var canvas	= generateLaserBodyCanvas(color.r,color.g,color.b)
 	var texture	= new THREE.Texture( canvas )
 	texture.needsUpdate	= true;
 	// do the material	
@@ -26,7 +36,13 @@ THREEx.LaserBeam	= function(){
 	}
 	return
 	
-	function generateLaserBodyCanvas(){
+	function generateLaserBodyCanvas(r,g,b){
+		var partialColor = {
+			r: Math.floor(r*160.0/255.0),
+			g: Math.floor(g*160.0/255.0),
+			b: Math.floor(b*160.0/255.0)
+		}
+
 		// init canvas
 		var canvas	= document.createElement( 'canvas' );
 		var context	= canvas.getContext( '2d' );
@@ -35,9 +51,9 @@ THREEx.LaserBeam	= function(){
 		// set gradient
 		var gradient	= context.createLinearGradient(0, 0, canvas.width, canvas.height);		
 		gradient.addColorStop( 0  , 'rgba(  0,  0,  0,0.1)' );
-		gradient.addColorStop( 0.1, 'rgba(160,160,160,0.3)' );
-		gradient.addColorStop( 0.5, 'rgba(255,255,255,0.5)' );
-		gradient.addColorStop( 0.9, 'rgba(160,160,160,0.3)' );
+		gradient.addColorStop( 0.1, 'rgba('+partialColor.r+','+partialColor.g+','+partialColor.b+',0.3)' );
+		gradient.addColorStop( 0.5, 'rgba('+r+','+g+','+b+',0.5)' );
+		gradient.addColorStop( 0.9, 'rgba('+partialColor.r+','+partialColor.g+','+partialColor.b+',0.3)' );
 		gradient.addColorStop( 1.0, 'rgba(  0,  0,  0,0.1)' );
 		// fill the rectangle
 		context.fillStyle	= gradient;


### PR DESCRIPTION
Cool extension! I'm using it for a space combat flight simulator I'm building, for which it was useful to have lasers of different colors.

Creating this PR in case that might be a useful feature for other people.

API is documented in README. Essentially, pass a {r: 255, g: 255, b: 255} object as the first argument. If no argument is passed, it defaults to white.
